### PR TITLE
Impl Send for Lib on Unix and Windows

### DIFF
--- a/src/os/unix/lib.rs
+++ b/src/os/unix/lib.rs
@@ -74,6 +74,8 @@ impl Lib {
     }
 }
 
+unsafe impl Send for Lib{}
+
 impl Drop for Lib {
     fn drop(&mut self) {
         util::error_guard(

--- a/src/os/windows/lib.rs
+++ b/src/os/windows/lib.rs
@@ -73,6 +73,8 @@ impl Lib {
     }
 }
 
+unsafe impl Send for Lib{}
+
 impl Drop for Lib {
     fn drop(&mut self) {
         util::error_guard(


### PR DESCRIPTION
Patch implements marker Send for Lib structs in os module. Send will propagate to LibUnsafe, Lib, LibTracked, LibRc and LibArc.

Closes #4